### PR TITLE
Fix the call to the carmine wcar fn

### DIFF
--- a/src/turnstile/core.clj
+++ b/src/turnstile/core.clj
@@ -18,27 +18,27 @@
       (car/zremrangebyscore name 0 (- now-ms expiration-ms 1)))
     this)
   (space [this limit]
-    (- limit (car/wcar pool conn-spec (car/zcard name))))
+    (- limit (car/wcar {:pool pool :spec conn-spec} (car/zcard name))))
   (has-space? [this limit]
     (<  (car/wcar pool conn-spec
           (car/zcard name)) limit))
   (next-slot [this limit now-ms]
-    (if-let [earliest (first (car/wcar pool conn-spec (car/zrange name 0 1)))]
-      (let [request-time (or (read-string (car/wcar conn-spec (car/zscore name earliest)))
+    (if-let [earliest (first (car/wcar {:pool pool :spec conn-spec} (car/zrange name 0 1)))]
+      (let [request-time (or (read-string (car/wcar {:pool pool :spec conn-spec} (car/zscore name earliest)))
                              0)]
         (max 0 (- (+ expiration-ms request-time)
                   now-ms)))
       0))
   (add-timed-item [this item time-ms]
-    (car/wcar pool conn-spec
+    (car/wcar {:pool pool :spec conn-spec}
       (car/zadd name time-ms item)
       (car/pexpire name (+ expiration-ms 1000))
       this))
   (delete-item [this item]
-    (car/wcar pool conn-spec
+    (car/wcar {:pool pool :spec conn-spec}
       (car/zrem name item))
     this)
   (reset [this]
-    (car/wcar pool conn-spec
+    (car/wcar {:pool pool :spec conn-spec}
       (car/del name))
     this))

--- a/test/turnstile/core_test.clj
+++ b/test/turnstile/core_test.clj
@@ -21,11 +21,11 @@
 
     (add-timed-item turnstile req-id now-ms)
 
-    (is (= req-id (first (car/wcar test-pool test-conn
+    (is (= req-id (first (car/wcar {:pool test-pool :spec test-conn}
                            (car/zrange "test-turnstile" 0 1))))
         "item is added to turnstile")
 
-    (is (= now-ms (read-string (car/wcar test-pool test-conn
+    (is (= now-ms (read-string (car/wcar {:pool test-pool :spec test-conn}
                                  (car/zscore "test-turnstile" req-id))))
         "item time is set correctly.")
 
@@ -56,11 +56,11 @@
 
     (add-timed-item turnstile req-id (+ 1 now-ms))
     (add-timed-item turnstile (make-token) (+ 2 now-ms))
-    (is (= 2 (car/wcar test-pool test-conn (car/zcard "test-turnstile")))
+    (is (= 2 (car/wcar {:pool test-pool :spec test-conn} (car/zcard "test-turnstile")))
         "multiple items added.")
 
     (reset turnstile)
-    (is (= 0 (car/wcar test-pool test-conn (car/zcard "test-turnstile")))
+    (is (= 0 (car/wcar {:pool test-pool :spec test-conn} (car/zcard "test-turnstile")))
         "reset clears all items")
 
     (is (has-space? turnstile 10)


### PR DESCRIPTION
The connection composed of a spec and a pool should be passed as a map